### PR TITLE
Support snRNA-seq

### DIFF
--- a/src/seqc/core/parser.py
+++ b/src/seqc/core/parser.py
@@ -105,7 +105,7 @@ def parse_args(args):
     # right now, it doesn't do much except you can override the default value for `--max-insert-size`
     f.add_argument(
         '--filter-mode', dest='filter_mode', type=str, default="scRNA-seq",
-        help='Indicate whether this is to process a snRNA-seq data'
+        help='Either "scRNA-seq" or "snRNA-seq")'
     )
 
     s = p.add_argument_group('alignment arguments')

--- a/src/seqc/core/parser.py
+++ b/src/seqc/core/parser.py
@@ -105,7 +105,7 @@ def parse_args(args):
     # right now, it doesn't do much except you can override the default value for `--max-insert-size`
     f.add_argument(
         '--filter-mode', dest='filter_mode', type=str, default="scRNA-seq",
-        help='Either "scRNA-seq" or "snRNA-seq")'
+        help='Either "scRNA-seq" or "snRNA-seq"'
     )
 
     s = p.add_argument_group('alignment arguments')

--- a/src/seqc/core/parser.py
+++ b/src/seqc/core/parser.py
@@ -102,6 +102,11 @@ def parse_args(args):
                    help='FDR rate for low coverage reads filter in mars-seq datasets. '
                         'Float between 0 and 1, default=0.25',
                    default=0.25, type=float)
+    # right now, it doesn't do much except you can override the default value for `--max-insert-size`
+    f.add_argument(
+        '--filter-mode', dest='filter_mode', type=str, default="scRNA-seq",
+        help='Indicate whether this is to process a snRNA-seq data'
+    )
 
     s = p.add_argument_group('alignment arguments')
     s.add_argument('--star-args', default=None, nargs='*',

--- a/src/seqc/core/run.py
+++ b/src/seqc/core/run.py
@@ -227,11 +227,27 @@ def run(args) -> None:
             log.notify('mutt was not found on this machine; an email will not be sent to '
                        'the user upon termination of SEQC run.')
 
-        max_insert_size = args.max_insert_size
+        # turn off lower coverage filter for 10x
         if (args.platform == "ten_x") or (args.platform == "ten_x_v2") or (args.platform == "ten_x_v3"):
-            max_insert_size = 10000
-            log.notify("Full length transcripts are used for read mapping in 10x data.")
             args.filter_low_coverage = False
+
+        max_insert_size = args.max_insert_size
+        if args.filter_mode == "scRNA-seq":
+            # for scRNA-seq
+            if (args.platform == "ten_x") or (args.platform == "ten_x_v2") or (args.platform == "ten_x_v3"):
+                # set max_transcript_length (max_insert_size) = 10000
+                max_insert_size = 10000
+                log.notify("Full length transcripts are used for read mapping in 10x data.")
+        elif args.filter_mode == "snRNA-seq":
+            # for snRNA-seq
+            # e.g. 2304700 # hg38
+            # e.g. 4434881 # mm38
+            max_insert_size = args.max_insert_size
+        else:
+            # all others
+            max_insert_size = args.max_insert_size
+
+        log.notify("max_insert_size is set to {}".format(max_insert_size))
 
         log.args(args)
 

--- a/src/seqc/notebooks/analysis_template.json
+++ b/src/seqc/notebooks/analysis_template.json
@@ -83,7 +83,7 @@
     "# set some plotting parameters\n",
     "matplotlib.rcParams['figure.figsize'] = [4, 4]\n",
     "matplotlib.rcParams['figure.dpi'] = 100\n",
-    "matplotlib.rcParams['figure.dpi'] = 100\n",
+    "matplotlib.rcParams['figure.facecolor'] = 'white'\n",
     "warnings.filterwarnings(action=\"ignore\", module=\"matplotlib\", message=\"findfont\")"
    ]
   },


### PR DESCRIPTION
- Add `--filter-mode`.
- Allow to override `--max_insert_size` if the filter mode is `snRNA-seq`.
- Set figure facecolor to white by default in the analysis notebook template.