### PR TITLE
v0.2.7

### DIFF
--- a/src/seqc/core/parser.py
+++ b/src/seqc/core/parser.py
@@ -253,7 +253,7 @@ def parse_args(args):
     start.add_argument(
         "-t",
         "--instance-type",
-        default="r5.2xlarge",
+        default="r5.4xlarge",
         help="AWS instance type to initialize. "
         "See https://aws.amazon.com/ec2/instance-types/ for valid types",
     )
@@ -368,7 +368,7 @@ def parse_args(args):
         )
         r.add_argument(
             "--instance-type",
-            default="r5.2xlarge",
+            default="r5.4xlarge",
             help="AWS instance type to initialize for this job. "
             "See https://aws.amazon.com/ec2/instance-types/ for valid types",
         )

--- a/src/seqc/core/run.py
+++ b/src/seqc/core/run.py
@@ -415,7 +415,7 @@ def run(args) -> None:
             # 121319782799149 / 512866590 / pos=49490848 / TCAATTAATC (1 hemming dist away from TCAATTAATT)
             # ra.data["rmt"][91490] = 512866590
             # ra.positions[91490] = 49492038
-            
+
 
 
             # correct errors
@@ -619,7 +619,11 @@ def run(args) -> None:
                 % (args.alignment_file, args.upload_prefix)
             )
 
-        log.info("SEQC run complete. Cluster will be terminated")
+        log.info("SEQC run complete.")
+
+        end_run_time = pendulum.now()
+        running_time = end_run_time - start_run_time
+        log.info("Running Time={}".format(running_time.in_words()))
 
         # upload logs
         if args.upload_prefix:
@@ -656,6 +660,3 @@ def run(args) -> None:
             email_body = email_body.replace("\n", "<br>").replace("\t", "&emsp;")
             email_user(summary_archive, email_body, args.email)
 
-        end_run_time = pendulum.now()
-        running_time = end_run_time - start_run_time
-        log.info("Running Time={}".format(running_time.in_words()))

--- a/src/seqc/rmt_correction.py
+++ b/src/seqc/rmt_correction.py
@@ -262,8 +262,8 @@ def _calc_max_workers(ra):
     # ra.data, ra.genes, and ra.positions are all numpy array
     ra_size = ra.data.nbytes + ra.genes.nbytes + ra.positions.nbytes
 
-    # extra bytes needed
-    extra = 2 * 1024 ** 3
+    # extra bytes needed (4GB)
+    extra = 4 * 1024 ** 3
 
     n = math.floor(_get_available_memory() / (ra_size + extra))
 

--- a/src/seqc/tests/test_run_rmt_correction.py
+++ b/src/seqc/tests/test_run_rmt_correction.py
@@ -34,7 +34,7 @@ class TestRmtCorrection(TestCase):
 
         n_workers = rmt_correction._calc_max_workers(self.ra)
 
-        self.assertEqual(n_workers, 7)
+        self.assertEqual(n_workers, 5)
 
     # 1TB
     @mock.patch("seqc.rmt_correction._get_available_memory", return_value=1079354630144)
@@ -42,7 +42,7 @@ class TestRmtCorrection(TestCase):
 
         n_workers = rmt_correction._calc_max_workers(self.ra)
 
-        self.assertEqual(n_workers, 156)
+        self.assertEqual(n_workers, 119)
 
     # having less memory than ra size
     @mock.patch("seqc.rmt_correction._get_available_memory")


### PR DESCRIPTION
- Increase memory requirements for RMT correction.
- Use `r5.4xlarge` as default instance type.
- Log the running time before uploading the log file.